### PR TITLE
Fix environment variables for cli update execution

### DIFF
--- a/extensions/azure/src/dependabot/cli.ts
+++ b/extensions/azure/src/dependabot/cli.ts
@@ -131,7 +131,7 @@ export class DependabotCli {
       if (!fs.existsSync(jobOutputPath) || fs.statSync(jobOutputPath)?.size == 0) {
         section(`Processing job from '${jobInputPath}'`);
         const additionalEnv = {
-          DEPENDABOT_JOB_ID: jobId.replace(/-/g, "_"), // replace hyphens with underscores
+          DEPENDABOT_JOB_ID: jobId.replace(/-/g, '_'), // replace hyphens with underscores
           LOCAL_GITHUB_ACCESS_TOKEN: options?.gitHubAccessToken, // avoid rate-limiting when pulling images from GitHub container registries
           LOCAL_AZURE_ACCESS_TOKEN: options?.azureDevOpsAccessToken, // technically not needed since we already supply this in our 'git_source' registry, but included for consistency
           FAKE_API_PORT: options?.apiListeningPort, // used to pin PORT of the Dependabot CLI api back-channel

--- a/extensions/azure/src/dependabot/cli.ts
+++ b/extensions/azure/src/dependabot/cli.ts
@@ -130,18 +130,20 @@ export class DependabotCli {
       // Run dependabot update
       if (!fs.existsSync(jobOutputPath) || fs.statSync(jobOutputPath)?.size == 0) {
         section(`Processing job from '${jobInputPath}'`);
+        const additionalEnv = {
+          DEPENDABOT_JOB_ID: jobId.replace(/-/g, "_"), // replace hyphens with underscores
+          LOCAL_GITHUB_ACCESS_TOKEN: options?.gitHubAccessToken, // avoid rate-limiting when pulling images from GitHub container registries
+          LOCAL_AZURE_ACCESS_TOKEN: options?.azureDevOpsAccessToken, // technically not needed since we already supply this in our 'git_source' registry, but included for consistency
+          FAKE_API_PORT: options?.apiListeningPort, // used to pin PORT of the Dependabot CLI api back-channel
+        };
+        const env = Object.assign({}, process.env, additionalEnv);
         const dependabotTool = tool(dependabotPath).arg(dependabotArguments);
         const dependabotResultCode = await dependabotTool.execAsync({
           outStream: this.outputLogStream,
           errStream: this.outputLogStream,
           ignoreReturnCode: true,
           failOnStdErr: false,
-          env: {
-            DEPENDABOT_JOB_ID: jobId.replace(/-/g, '_'), // replace hyphens with underscores
-            LOCAL_GITHUB_ACCESS_TOKEN: options?.gitHubAccessToken, // avoid rate-limiting when pulling images from GitHub container registries
-            LOCAL_AZURE_ACCESS_TOKEN: options?.azureDevOpsAccessToken, // technically not needed since we already supply this in our 'git_source' registry, but included for consistency
-            FAKE_API_PORT: options?.apiListeningPort, // used to pin PORT of the Dependabot CLI api back-channel
-          },
+          env: env,
         });
         if (dependabotResultCode != 0) {
           error(`Dependabot failed with exit code ${dependabotResultCode}`);


### PR DESCRIPTION
Execute dependabot update job with full environment

Setting `env` in `dependabotTool.execAsync(` only sets these environment variables and in my case the available environment variables to use a proxy configuration (like `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`) gets removed.

So just merging the existing environment variables with the additional ones.